### PR TITLE
Remove dead /login and /register routes that ENOENT on every hit

### DIFF
--- a/server.js
+++ b/server.js
@@ -36,22 +36,6 @@ app.get('/changeLog.html', (req, res) => {
   res.sendFile(path.join(__dirname, 'public/pages/changeLog/changeLog.html'));
 });
 
-app.get('/login', (req, res) => {
-  res.sendFile(path.join(__dirname, 'public/pages/login/login.html'));
-});
-
-app.get('/login.html', (req, res) => {
-  res.sendFile(path.join(__dirname, 'public/pages/login/login.html'));
-});
-
-app.get('/register', (req, res) => {
-  res.sendFile(path.join(__dirname, 'public/pages/register/register.html'));
-});
-
-app.get('/register.html', (req, res) => {
-  res.sendFile(path.join(__dirname, 'public/pages/register/register.html'));
-});
-
 app.get('/sandbox', (req, res) => {
   res.sendFile(path.join(__dirname, 'public/pages/sandbox/sandbox.html'));
 });


### PR DESCRIPTION
## Problem

Every request to `/login`, `/login.html`, `/register`, or `/register.html` on wreckingwheels.com throws an `ENOENT` error and returns a 404. These routes have been silently flooding the pm2 logs — **399 ENOENT lines in the last 2000 log lines** as of 2026-06-28, ongoing (mostly bots/scanners probing `/login`, plus the occasional real probe).

**Root cause** — `server.js:39` (and the three routes below it):

```js
app.get('/login', (req, res) => {
  res.sendFile(path.join(__dirname, 'public/pages/login/login.html'));
});
// ...and /login.html, /register, /register.html, same pattern
```

These `sendFile` targets — `public/pages/login/` and `public/pages/register/` — were **deleted in commit `fabd5b3`** ("refactor: remove unused login and register folders", Apr 2024) when login/register became popups instead of standalone pages. The page folders went away; the route handlers were left behind. So `sendFile` stats a file that no longer exists, logs `ENOENT`, and returns a 404.

No working feature depends on these routes — login is a popup now, the pages are gone, and nothing reachable links to `/login`/`/register` (the one stray reference, `changeLog_future.js:67`, lives in an orphan file no HTML page loads).

## Reproduction (on the live box)

```sh
# Each returns 404...
curl -s -o /dev/null -w '%{http_code}\n' https://wreckingwheels.com/login        # 404
curl -s -o /dev/null -w '%{http_code}\n' https://wreckingwheels.com/register     # 404

# ...and each leaves a fresh ENOENT in the app log:
ssh personal-server "pm2 logs server --lines 200 --nostream 2>/dev/null | grep -c \"ENOENT.*pages/login/login.html\""
```

## Fix

Delete the four dead route handlers. Requests then fall through to Express's default 404 handler — the **same 404 the user already saw**, minus the missing-file stat and the error-log line.

## Before / after (run locally on this branch's parent vs. this branch)

```
                 BEFORE (origin/main)        AFTER (this branch)
/login        -> 404 + ENOENT logged      -> 404, no log
/login.html   -> 404 + ENOENT logged      -> 404, no log
/register     -> 404 + ENOENT logged      -> 404, no log
/register.html-> 404 + ENOENT logged      -> 404, no log

Control routes unchanged on both:  /  /changelog  /sandbox  /other-games  -> 200
```

Before, the server log after those four requests:
```
Error: ENOENT: no such file or directory, stat '.../public/pages/login/login.html'   (x2)
Error: ENOENT: no such file or directory, stat '.../public/pages/register/register.html' (x2)
```
After: zero ENOENT lines.

Low severity — no user-facing feature was broken (these only ever 404'd); this removes ongoing log noise and the per-request failed `stat`.

---
🤖 Opened by evergreen
